### PR TITLE
Added types to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "exports": {
     "require": "./dist/index.cjs",
-    "import": "./dist/index.mjs"
+    "import": "./dist/index.mjs",
+    "types": "./dist/index.d.ts"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Baby PR hahaha. I noticed that the package doesn't export its types; this PR adds that to package.json so the types can be used when importing the lib.