### PR TITLE
computer: add putFile command

### DIFF
--- a/lib/utils/urls.ts
+++ b/lib/utils/urls.ts
@@ -40,3 +40,10 @@ export function getMcpUrl(baseURL: string, machineId: string | null): string {
     throw new Error('Unable to get MCP Url: machineId is null.');
   return `${baseURL}${machineId}/mcp`;
 }
+
+export function getFileUrl(baseURL: string, machineId: string | null): string {
+  if (machineId === null) {
+    throw new Error('Unable to get File Url: machineId is null.');
+  }
+  return `${baseURL}${machineId}/file/upload`;
+}


### PR DESCRIPTION
Adds a putFile command that takes a file path, grabs the stream and POSTs it onto the machine. 

This *should* work given [our Hudson code](https://github.com/hdresearch/hudson/blob/43ad82da13fe78567adc91b1e8cf3b6fabe3b0b4/hudson_server/src/server/routes/system.rs#L36-L87
)?

But instead, it just gives a pleasant 200 with an empty response body, and never seems to put it on the machine in question. Can you confirm this is what we expect and why this might be the case @asebexen ?